### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
 
       - name: checkout repo content
-        uses: actions/checkout@v4.2.1 # checkout the repository content to GitHub runner
+        uses: actions/checkout@v4.2.2 # checkout the repository content to GitHub runner
 
 
       - name: setup python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: '3.12' # install the python version needed
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           # Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.3.0](https://github.com/actions/setup-python/releases/tag/v5.3.0)** on 2024-10-24T14:15:17Z
